### PR TITLE
feat: add multitenancy http handler

### DIFF
--- a/charts/dex-k8s-authenticator/templates/configmap.yaml
+++ b/charts/dex-k8s-authenticator/templates/configmap.yaml
@@ -23,9 +23,12 @@ data:
     {{- if .idpCaPem }}
     idp_ca_pem: {{ toYaml .idpCaPem | indent 4 }}
     {{- end }}
-    {{- if and .tlsCert .tlsKey }} 
+    {{- if and .tlsCert .tlsKey }}
     tls_cert: "{{ .tlsCert }}"
     tls_key: "{{ .tlsKey }}"
+    {{- end }}
+    {{- if .enableMultiTenancy }}
+    enable_multi_tenancy: true
     {{- end }}
     clusters:
 {{ toYaml .clusters | indent 4 }}

--- a/charts/dex-k8s-authenticator/values.yaml
+++ b/charts/dex-k8s-authenticator/values.yaml
@@ -18,6 +18,7 @@ dexK8sAuthenticator:
   #logoUrl: http://<path-to-your-logo.png>
   #tlsCert: /path/to/dex-client.crt
   #tlsKey: /path/to/dex-client.key
+  enableMultiTenancy: false
   clusters:
   - name: my-cluster
     short_description: "My Cluster"

--- a/dex-auth.go
+++ b/dex-auth.go
@@ -179,7 +179,7 @@ func (cluster *Cluster) handleCallback(w http.ResponseWriter, r *http.Request) {
 	rawIDToken, ok := token.Extra("id_token").(string)
 	if !ok {
 		cluster.renderHTMLError(w, userErrorMsg, http.StatusInternalServerError)
-		log.Printf("handleCallback: no id_token in response: %q", token)
+		log.Printf("handleCallback: no id_token in response: %v", token)
 		return
 	}
 

--- a/dex-auth.go
+++ b/dex-auth.go
@@ -15,6 +15,8 @@ import (
 	"github.com/spf13/cast"
 	"github.com/spf13/viper"
 	"golang.org/x/oauth2"
+
+	"github.com/mesosphere/dex-k8s-authenticator/pkg/tenancy"
 )
 
 const (
@@ -104,7 +106,14 @@ func (cluster *Cluster) handleLogin(w http.ResponseWriter, r *http.Request) {
 	}
 
 	log.Printf("Handling login-uri for: %s", cluster.Name)
-	authCodeURL := cluster.oauth2Config(scopes).AuthCodeURL(exampleAppState, oauth2.AccessTypeOffline)
+	opts := []oauth2.AuthCodeOption{
+		oauth2.AccessTypeOffline,
+	}
+	if tenantId := r.Form.Get(tenancy.TenantIdQueryParamName); tenantId != "" {
+		opts = append(opts, tenancy.OauthAddTenantId(tenancy.TenantId(tenantId)))
+	}
+
+	authCodeURL := cluster.oauth2Config(scopes).AuthCodeURL(exampleAppState, opts...)
 
 	// Record the name of cluster
 	http.SetCookie(w, &http.Cookie{

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,9 @@ go 1.13
 
 require (
 	github.com/coreos/go-oidc v2.2.1+incompatible
+	github.com/gorilla/context v1.1.1 // indirect
+	github.com/gorilla/mux v1.8.0 // indirect
+	github.com/gorilla/pat v1.0.1 // indirect
 	github.com/mesosphere/konvoy-async-auth v0.1.3
 	github.com/spf13/cast v1.5.0
 	github.com/spf13/cobra v1.4.0

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,7 @@ go 1.13
 
 require (
 	github.com/coreos/go-oidc v2.2.1+incompatible
-	github.com/gorilla/context v1.1.1 // indirect
-	github.com/gorilla/mux v1.8.0 // indirect
-	github.com/gorilla/pat v1.0.1 // indirect
+	github.com/gorilla/mux v1.8.0
 	github.com/mesosphere/konvoy-async-auth v0.1.3
 	github.com/spf13/cast v1.5.0
 	github.com/spf13/cobra v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -243,6 +243,12 @@ github.com/googleapis/gax-go/v2 v2.1.1/go.mod h1:hddJymUZASv3XPyGkUpKj8pPO47Rmb0
 github.com/googleapis/gax-go/v2 v2.2.0/go.mod h1:as02EH8zWkzwUoLbBaFeQ+arQaj/OthfcblKl4IGNaM=
 github.com/googleapis/gax-go/v2 v2.3.0/go.mod h1:b8LNqSzNabLiUpXKkY7HAR5jr6bIT99EXz9pXxye9YM=
 github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=
+github.com/gorilla/context v1.1.1 h1:AWwleXJkX/nhcU9bZSnZoi3h/qGYqQAGhq6zZe/aQW8=
+github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/gorilla/pat v1.0.1 h1:OeSoj6sffw4/majibAY2BAUsXjNP7fEE+w30KickaL4=
+github.com/gorilla/pat v1.0.1/go.mod h1:YeAe0gNeiNT5hoiZRI4yiOky6jVdNvfO2N6Kav/HmxY=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=

--- a/go.sum
+++ b/go.sum
@@ -243,12 +243,8 @@ github.com/googleapis/gax-go/v2 v2.1.1/go.mod h1:hddJymUZASv3XPyGkUpKj8pPO47Rmb0
 github.com/googleapis/gax-go/v2 v2.2.0/go.mod h1:as02EH8zWkzwUoLbBaFeQ+arQaj/OthfcblKl4IGNaM=
 github.com/googleapis/gax-go/v2 v2.3.0/go.mod h1:b8LNqSzNabLiUpXKkY7HAR5jr6bIT99EXz9pXxye9YM=
 github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=
-github.com/gorilla/context v1.1.1 h1:AWwleXJkX/nhcU9bZSnZoi3h/qGYqQAGhq6zZe/aQW8=
-github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
-github.com/gorilla/pat v1.0.1 h1:OeSoj6sffw4/majibAY2BAUsXjNP7fEE+w30KickaL4=
-github.com/gorilla/pat v1.0.1/go.mod h1:YeAe0gNeiNT5hoiZRI4yiOky6jVdNvfO2N6Kav/HmxY=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=

--- a/main.go
+++ b/main.go
@@ -20,10 +20,13 @@ import (
 	"time"
 
 	"github.com/coreos/go-oidc"
+	"github.com/gorilla/mux"
 	"github.com/mesosphere/konvoy-async-auth/pkg/kaal/server/storage"
 	memstorage "github.com/mesosphere/konvoy-async-auth/pkg/kaal/server/storage/memory"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+
+	"github.com/mesosphere/dex-k8s-authenticator/pkg/tenancy"
 )
 
 var (
@@ -70,8 +73,6 @@ type Cluster struct {
 	K8s_Ca_Pem          string
 	Static_Context_Name bool
 
-	Enable_Multi_Tenancy bool
-
 	Verifier       *oidc.IDTokenVerifier
 	Provider       *oidc.Provider
 	OfflineAsScope bool
@@ -97,6 +98,7 @@ type Config struct {
 	Hmac_Secret                      string
 	PluginVersion                    string
 	UseClusterHostnameForClusterName bool
+	Enable_Multi_Tenancy             bool
 }
 
 func substituteEnvVars(text string) string {
@@ -232,8 +234,7 @@ func start_app(config Config) {
 		base_redirect_uri, err := url.Parse(cluster.Redirect_URI)
 
 		if err != nil {
-			fmt.Errorf("Parsing redirect_uri address: %v", err)
-			os.Exit(1)
+			log.Fatalf("Parsing redirect_uri address: %v", err)
 		}
 
 		if base_redirect_uri.Path != commonCallbackPath {
@@ -262,6 +263,19 @@ func start_app(config Config) {
 	log.Printf("Registered static assets handler at: %s", static_uri)
 
 	http.Handle(static_uri, http.StripPrefix(static_uri, fs))
+
+	if config.Enable_Multi_Tenancy {
+		tenantBasePath := path.Join(config.Web_Path_Prefix, "workspace")
+		tenants, err := tenancy.NewK8sFromEnvironment()
+		if err != nil {
+			log.Fatalf("failed to initialize tenancy k8s client: %s", err)
+		}
+		log.Printf("Starting with multi-tenancy enabled on path %s", tenantBasePath)
+		r := mux.NewRouter().PathPrefix(tenantBasePath).Subrouter()
+		r.HandleFunc("/{tenantId}", NewTenancyHandler(
+			tenants, &config, templates.Lookup("index-multitenant.html")))
+		http.Handle(tenantBasePath, r)
+	}
 
 	// Setup async auth service and build routes
 	stg := memstorage.New(false)

--- a/main.go
+++ b/main.go
@@ -70,6 +70,8 @@ type Cluster struct {
 	K8s_Ca_Pem          string
 	Static_Context_Name bool
 
+	Enable_Multi_Tenancy bool
+
 	Verifier       *oidc.IDTokenVerifier
 	Provider       *oidc.Provider
 	OfflineAsScope bool

--- a/pkg/tenancy/oauth.go
+++ b/pkg/tenancy/oauth.go
@@ -1,0 +1,17 @@
+package tenancy
+
+import (
+	"golang.org/x/oauth2"
+)
+
+const (
+	// TenantIdQueryParamName is the name of URL request query parameter that must
+	// be carried to the Dex to filter out the connectors based on tenant id
+	TenantIdQueryParamName = "tenant-id"
+)
+
+// OauthAddTenantId adds tenant-id parameter to authorization URL where the
+// client is redirected.
+func OauthAddTenantId(tenantId TenantId) oauth2.AuthCodeOption {
+	return oauth2.SetAuthURLParam(TenantIdQueryParamName, string(tenantId))
+}

--- a/templates/index-multitenant.html
+++ b/templates/index-multitenant.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="google" content="notranslate">
+    <meta http-equiv="Content-Language" content="en">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+
+    <title>Generate Kubernetes Token</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link href="{{ .Web_Path_Prefix }}static/main.css" rel="stylesheet" type="text/css">
+    <link href="{{ .Web_Path_Prefix }}static/styles.css" rel="stylesheet" type="text/css">
+    <link rel="icon" href="{{ .Web_Path_Prefix }}static/favicon.png">
+  </head>
+
+  <body class="theme-body">
+    <div class="theme-navbar">
+      {{ if .Logo_Uri }}
+      <div class="theme-navbar__logo-wrap">
+          <img class="theme-navbar__logo" src="{{ .Logo_Uri }}"/>
+      </div>
+      {{ end }}
+    </div>
+
+    <div class="dex-container">
+
+      <div class="theme-panel">
+        <h2 class="theme-heading">Generate Kubernetes Token</h2>
+        <div>
+            <p>
+              Select which cluster you require a token for:
+            </p>
+
+            {{ range $cluster := .Clusters }}
+
+            <div class="theme-form-row">
+                <p class="theme-form-description">{{$cluster.Description}}</p>
+                <a href="{{ $.Web_Path_Prefix }}login/{{$cluster.Name}}?tenant-id={{ $.Tenant_Id }}" target="_self">
+                  <button class="dex-btn theme-btn-provider">
+                    <span class="dex-btn-icon dex-btn-icon--local"></span>
+                    <span class="dex-btn-text">{{$cluster.Short_Description}}</span>
+                  </button>
+                </a>
+              </div>
+              {{ end }}
+            </div>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/tenancy.go
+++ b/tenancy.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"html/template"
+	"log"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"k8s.io/utils/strings/slices"
+
+	"github.com/mesosphere/dex-k8s-authenticator/pkg/tenancy"
+)
+
+// NewTenancyHandler displays a page where the user can see a list of clusters
+// for given tenant.
+func NewTenancyHandler(tenants tenancy.Tenants, c *Config, templates *template.Template) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		tenantId := tenancy.TenantId(mux.Vars(r)["tenantId"])
+		exists, err := tenants.Exists(r.Context(), tenantId)
+		if err != nil {
+			log.Printf("Failed to check tenant: %s", err)
+			renderHTMLError(w, c, "Failed to check for tenant", http.StatusInternalServerError)
+			return
+		}
+
+		if !exists {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		allNames := []string{}
+		for i := range c.Clusters {
+			allNames = append(allNames, c.Clusters[i].Name)
+		}
+		tenantClusterNames, err := tenants.FilterClusterNames(r.Context(), tenantId, allNames)
+		if err != nil {
+			log.Printf("Failed to filter cluster name: %s", err)
+			renderHTMLError(w, c, "Failed to check for tenant", http.StatusInternalServerError)
+			return
+		}
+
+		tenantClusters := []Cluster{}
+		for i := range c.Clusters {
+			if slices.Contains(tenantClusterNames, c.Clusters[i].Name) {
+				tenantClusters = append(tenantClusters, c.Clusters[i])
+			}
+		}
+
+		data := struct {
+			Web_Path_Prefix string
+			Logo_Uri        string
+			Clusters        []Cluster
+			Tenant_Id       string
+		}{
+			Web_Path_Prefix: c.Web_Path_Prefix,
+			Logo_Uri:        c.Logo_Uri,
+			Clusters:        tenantClusters,
+			Tenant_Id:       string(tenantId),
+		}
+		err = templates.Execute(w, data)
+		if err != nil {
+			renderHTMLError(w, c, "Failed to render template", http.StatusInternalServerError)
+		}
+	}
+}

--- a/tenancy_test.go
+++ b/tenancy_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/mesosphere/dex-k8s-authenticator/pkg/tenancy"
+)
+
+func TestMultitenantIndex(t *testing.T) {
+	assert.NotNil(t, templates.Lookup("index-multitenant.html"))
+}
+
+func TestTenancyHandler(t *testing.T) {
+	m := &tenantsMock{
+		existsCall: struct {
+			exists bool
+			err    error
+		}{
+			exists: true,
+		},
+		filterClusterNamesCall: struct {
+			names []string
+			err   error
+		}{
+			names: []string{"cluster-2"},
+		},
+	}
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/test-tenant", nil)
+	c := &Config{
+		Clusters: []Cluster{
+			{Name: "cluster-1"},
+			{Name: "cluster-2"},
+		},
+		Web_Path_Prefix: "/",
+	}
+
+	h := NewTenancyHandler(m, c, templates.Lookup("index-multitenant.html"))
+	r := mux.NewRouter()
+	r.HandleFunc("/{tenantId}", h)
+	r.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code, "respbody: %s", rr.Body.String())
+	assert.Contains(t, rr.Body.String(), "/login/cluster-2?tenant-id=test-tenant")
+}
+
+var _ tenancy.Tenants = &tenantsMock{}
+
+type tenantsMock struct {
+	existsCall struct {
+		exists bool
+		err    error
+	}
+
+	filterClusterNamesCall struct {
+		names []string
+		err   error
+	}
+}
+
+func (t *tenantsMock) Exists(ctx context.Context, tenantId tenancy.TenantId) (bool, error) {
+	return t.existsCall.exists, t.existsCall.err
+}
+
+func (t *tenantsMock) FilterClusterNames(ctx context.Context, tenantId tenancy.TenantId, names []string) ([]string, error) {
+	return t.filterClusterNamesCall.names, t.filterClusterNamesCall.err
+}


### PR DESCRIPTION
Adds a new HTTP handler on `/workspace/<tenant-id>` that will list limited number of clusters and adds `tenant-id` paramter to oauth redirect URL.